### PR TITLE
Recursivly discover Gemfile

### DIFF
--- a/rake.el
+++ b/rake.el
@@ -95,10 +95,7 @@
   (file-exists-p (expand-file-name ".zeus.sock" root)))
 
 (defun rake--bundler-p (root)
-  (cond
-   ((file-exists-p (expand-file-name "Gemfile" root)) t)
-   ((equal (expand-file-name root) "/") nil)
-   (t (rake--bundler-p (concat (file-name-as-directory root) "..")))))
+  (locate-dominating-file root "Gemfile"))
 
 (defun rake--vertical-ido-on-p ()
   (and

--- a/rake.el
+++ b/rake.el
@@ -95,7 +95,10 @@
   (file-exists-p (expand-file-name ".zeus.sock" root)))
 
 (defun rake--bundler-p (root)
-  (file-exists-p (expand-file-name "Gemfile" root)))
+  (cond
+   ((file-exists-p (expand-file-name "Gemfile" root)) t)
+   ((equal (expand-file-name root) "/") nil)
+   (t (rake--bundler-p (concat (file-name-as-directory root) "..")))))
 
 (defun rake--vertical-ido-on-p ()
   (and


### PR DESCRIPTION
Rakefiles can reside in subdirectories, with the Gemfile being located
at the project root, a good example for such a project is rails, where
each subdirectory has a Rakefile appropriate for its subproject but the
Gemfile is located all the way up at the root of rails itself.

A structure like this

```
~/sampledir $ tree
.
├── Gemfile
└── subdir
    └── Rakefile
```

In this case rake needs to still be run using bundle exec to make sure
the proper version of rake is used. To make this work the Rakefile
searched from the current rake root upwards.